### PR TITLE
Rename page name from GitHub Issues to Devin: GitHub Issues

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "GitHub Issues Dashboard",
+  title: "Devin: GitHub Issues Dashboard",
   description: "View and manage GitHub issues from any repository",
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -110,7 +110,8 @@ export default function Dashboard() {
               </div>
               <div>
                 <h1 className="text-lg font-bold tracking-tight">
-                  GitHub Issues
+                  Devin: GitHub Issues
+
                 </h1>
                 <p className="text-xs text-muted-foreground font-medium">
                   {repo}


### PR DESCRIPTION
Fixes #22

Updated:
- Browser tab title
- Page header text
